### PR TITLE
String.*strip/2 Depreciated

### DIFF
--- a/lib/plug_forwarded_peer.ex
+++ b/lib/plug_forwarded_peer.ex
@@ -22,7 +22,7 @@ defmodule PlugForwardedPeer do
     end
   end
   def clean_ip(maybe_quoted_ip) do
-    maybe_ip = maybe_quoted_ip |> String.strip(?") |> String.rstrip(?]) |> String.lstrip(?[)
+    maybe_ip = maybe_quoted_ip |> String.trim(?") |> String.trim_trailing(?]) |> String.trim_leading(?[)
     case :inet_parse.address('#{maybe_ip}') do
       {:ok,ip}->ip
       _->nil


### PR DESCRIPTION
Great article by the way; it's nice to read more practical guides on Phoenix.

One slight improvement is that the `String.*strip/2` functions were soft depreciated in Elixir 1.3 in favour of `String.trim*/2`. Starting with 1.6 these depreciations become a lot noisier. Swapping them out is all that's required in your example.

See: https://github.com/elixir-lang/elixir/blob/v1.3/CHANGELOG.md#3-soft-deprecations-no-warnings-emitted